### PR TITLE
fix: add tree-sitter.json in order to use tree-sitter cli

### DIFF
--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://tree-sitter.github.io/tree-sitter/assets/schemas/config.schema.json",
+  "grammars": [
+    {
+      "name": "gritql",
+      "camelcase": "GritQL",
+      "title": "GritQL",
+      "scope": "source.grit",
+      "file-types": ["gritql"],
+      "injection-regex": "^gritql$",
+      "class-name": "TreeSitterGritql"
+    }
+  ],
+  "metadata": {
+    "version": "0.1.0",
+    "license": "MIT",
+    "description": "Gritql grammar for tree-sitter",
+    "links": {
+      "repository": "https://github.com/honeycombio/tree-sitter-gritql"
+    }
+  },
+  "bindings": {
+    "node": true,
+    "rust": true
+  }
+}


### PR DESCRIPTION
While building https://github.com/biomejs/biome-zed/issues/125 (GritQL syntax highlighting), I needed to spin up the [playground](https://tree-sitter.github.io/tree-sitter/7-playground.html#about) to debug the syntax tree.

`tree-sitter.json` is required in order to run `tree-sitter build --wasm` to build the playground locally.

This PR is a subset of https://github.com/honeycombio/tree-sitter-gritql/pull/23 and only includes the bare minimum to enable building the playground.

To verify the changes

```
$ tree-sitter build --wasm
$ tree-sitter playground
```

Beside playground, `tree-sitter.json` is used by `tree-sitter` cli for other purposes. See https://tree-sitter.github.io/tree-sitter/3-syntax-highlighting.html#language-configuration.
