### PR TITLE
fix(ci): repair CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,11 @@ on:
       - src/**
       - bindings/**
       - binding.gyp
-  pull_request:
-    paths:
-      - grammar.js
-      - src/**
-      - bindings/**
-      - binding.gyp
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
 
 jobs:
   test:

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     }
   },
   "devDependencies": {
-    "tree-sitter-cli": "~0.21.0-pre-release-1",
+    "tree-sitter-cli": "~0.25.9",
     "prebuildify": "^6.0.0"
   },
   "tree-sitter": [


### PR DESCRIPTION
CI needs a new version of the tree sitter CLI for fef4749fcb5b4a08e90d7dd33c4e87da35a81cab to pass.

Also update it to run CI on PRs so we detect problems before merging.